### PR TITLE
Allow more valid characters for prom label

### DIFF
--- a/lib/prometheus_parser.ex
+++ b/lib/prometheus_parser.ex
@@ -79,7 +79,7 @@ defmodule PrometheusParser do
     |> tag(:documentation)
 
   prom_label =
-    ascii_char([?a..?z])
+    ascii_char([?a..?z] ++ [?A..?Z] ++ [?_])
     |> lookahead()
     |> ascii_string([?a..?z, ?A..?Z] ++ [?0..?9] ++ [?_], min: 1)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PrometheusParser.MixProject do
   def project do
     [
       app: :prometheus_parser,
-      version: "0.1.9",
+      version: "0.1.10",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PrometheusParser.MixProject do
   def project do
     [
       app: :prometheus_parser,
-      version: "0.1.10",
+      version: "0.1.11",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/prometheus_parser_test.exs
+++ b/test/prometheus_parser_test.exs
@@ -54,6 +54,7 @@ defmodule PrometheusParserTest do
     assert parse("720_pending_messages 0") ==
              {:error, "Unsupported syntax: \"720_pending_messages 0\""}
   end
+  
 
   test "parse entry without key and value" do
     assert parse("pending_messages 0") ==
@@ -315,5 +316,19 @@ defmodule PrometheusParserTest do
              value: "607180"
            }) ==
              "web_connections{node=\"abc-123-def-0\"} 607180 1234"
+  end
+
+  test "parse label with single character name" do
+    assert parse(~s(f 1234)) ==
+      {:ok,
+        %PrometheusParser.Line{
+          documentation: nil,
+          label: "f",
+          line_type: "ENTRY",
+          pairs: [],
+          timestamp: nil,
+          type: nil,
+          value: "1234",
+        }}
   end
 end

--- a/test/prometheus_parser_test.exs
+++ b/test/prometheus_parser_test.exs
@@ -54,7 +54,6 @@ defmodule PrometheusParserTest do
     assert parse("720_pending_messages 0") ==
              {:error, "Unsupported syntax: \"720_pending_messages 0\""}
   end
-  
 
   test "parse entry without key and value" do
     assert parse("pending_messages 0") ==


### PR DESCRIPTION
According to https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels, capital letters are valid as the first character. This allows parsing something like https://github.com/NVIDIA/dcgm-exporter.

This is not actually a complete fix for parsing, since metric names and metric labels have a slightly different form, but this fixes an issue someone on slack was having with this package.